### PR TITLE
Pass params when UmbralPrivateKey.public_key() creates an UmbralPublicKey

### DIFF
--- a/umbral/keys.py
+++ b/umbral/keys.py
@@ -121,7 +121,7 @@ class UmbralPrivateKey(object):
         """
         Calculates and returns the public key of the private key.
         """
-        return UmbralPublicKey(self.bn_key * self.params.g)
+        return UmbralPublicKey(self.bn_key * self.params.g, params=self.params)
 
     def to_cryptography_privkey(self):
         """


### PR DESCRIPTION
Looks like not passing the curve was causing the segfault